### PR TITLE
Fix algorand.toml

### DIFF
--- a/data/ecosystems/a/algorand.toml
+++ b/data/ecosystems/a/algorand.toml
@@ -9191,12 +9191,6 @@ url = "https://github.com/parichard/Algomond-code"
 url = "https://github.com/parity-asia/hackathon-2022-winter"
 
 [[repo]]
-url = "https://github.com/parseb/cashcow-quest"
-
-[[repo]]
-url = "https://github.com/parseb/promise.monster"
-
-[[repo]]
 url = "https://github.com/paspalabab/metaone-algorand"
 
 [[repo]]


### PR DESCRIPTION
Removed my EVM projects from Algorand Ecosystem.
They have never been developed or deployed on algorand.  Nor can they be.